### PR TITLE
Limitar categorias para assinatura

### DIFF
--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -527,6 +527,19 @@ const app = {
         }
       },
       hide: false
+    },
+    recurrency_category_ids: {
+      schema: {
+        title: 'Categorias para assinatura',
+        description: 'Opcional para limitar as categorias disponíveis para assinatura, por padrão todos os produtos da loja serão assináveis',
+        type: 'array',
+        items: {
+          type: 'string',
+          pattern: '^[a-f0-9]{24}$',
+          title: 'ID da categoria'
+        }
+      },
+      hide: false
     }
   }
 }


### PR DESCRIPTION
Abrindo essa PR para já especificar o field do admin settings, baseado nele o campo será renderizado diferente no admin (autocomplete para buscar a categoria).
O campo pode estar em outro lugar, só deve ter nome `*category_ids*`